### PR TITLE
Avoid duplicated events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ store.json
 logs
 data
 .idea/
+*.code-workspace
+Matrix-EmailBridge

--- a/main/FileStore.go
+++ b/main/FileStore.go
@@ -83,3 +83,14 @@ func (fs *FileStore) SaveRoom(room *mautrix.Room) {
 func (fs *FileStore) LoadRoom(roomID id.RoomID) *mautrix.Room {
 	return fs.Rooms[roomID]
 }
+
+func (fs *FileStore) UpdateRoomState(roomID id.RoomID, statusKey string, evt *event.Event) {
+	room := fs.LoadRoom(roomID)
+	if room == nil {
+		room = mautrix.NewRoom(roomID)
+		fs.SaveRoom(room)
+	}
+	if room.State[event.StateMember][statusKey].Timestamp < evt.Timestamp {
+		room.UpdateState(evt)
+	}
+}

--- a/main/FileStore.go
+++ b/main/FileStore.go
@@ -14,10 +14,9 @@ import (
 type FileStore struct {
 	path string
 
-	FilterID    string                         `json:"filter_id"`
-	NextBatch   string                         `json:"next_batch"`
-	Rooms       map[id.RoomID]*mautrix.Room    `json:"rooms"`
-	Memberships map[id.RoomID]event.Membership `json:"memberships"`
+	FilterID  string                      `json:"filter_id"`
+	NextBatch string                      `json:"next_batch"`
+	Rooms     map[id.RoomID]*mautrix.Room `json:"rooms"`
 }
 
 //NewFileStore creates a new filestore
@@ -93,4 +92,9 @@ func (fs *FileStore) UpdateRoomState(roomID id.RoomID, statusKey string, evt *ev
 	if room.State[event.StateMember][statusKey].Timestamp < evt.Timestamp {
 		room.UpdateState(evt)
 	}
+}
+
+func (fs *FileStore) GetMembership(roomID id.RoomID, statusKey id.UserID) event.Membership {
+	room := fs.LoadRoom(roomID)
+	return room.GetMembershipState(statusKey)
 }

--- a/main/FileStore.go
+++ b/main/FileStore.go
@@ -51,24 +51,24 @@ func (fs *FileStore) Load() error {
 }
 
 //SaveFilterID sets filterID and saves
-func (fs *FileStore) SaveFilterID(userID id.UserID, filterID string) {
+func (fs *FileStore) SaveFilterID(_ id.UserID, filterID string) {
 	fs.FilterID = filterID
 	fs.Save()
 }
 
 //LoadFilterID loadsFilterID
-func (fs *FileStore) LoadFilterID(userID id.UserID) string {
+func (fs *FileStore) LoadFilterID(_ id.UserID) string {
 	return fs.FilterID
 }
 
 //SaveNextBatch saves Next batch
-func (fs *FileStore) SaveNextBatch(userID id.UserID, nextBatchToken string) {
+func (fs *FileStore) SaveNextBatch(_ id.UserID, nextBatchToken string) {
 	fs.NextBatch = nextBatchToken
 	fs.Save()
 }
 
 //LoadNextBatch loads  next batch
-func (fs *FileStore) LoadNextBatch(userID id.UserID) string {
+func (fs *FileStore) LoadNextBatch(_ id.UserID) string {
 	return fs.NextBatch
 }
 
@@ -94,7 +94,7 @@ func (fs *FileStore) UpdateRoomState(roomID id.RoomID, evt *event.Event) {
 	}
 }
 
-func (fs *FileStore) GetMembership(roomID id.RoomID) event.Membership {
+func (fs *FileStore) GetMembershipState(roomID id.RoomID) (event.Membership, int64) {
 	room := fs.LoadRoom(roomID)
-	return room.GetMembershipState(fs.userID)
+	return room.GetMembershipState(fs.userID), room.State[event.StateMember][string(fs.userID)].Timestamp
 }

--- a/main/FileStore.go
+++ b/main/FileStore.go
@@ -2,26 +2,33 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 
 	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
 )
 
 //FileStore required by the bridgeAPI
 type FileStore struct {
 	path string
 
-	FilterID  string                   `json:"filter_id"`
-	NextBatch string                   `json:"next_batch"`
-	Rooms     map[string]*mautrix.Room `json:"-"`
+	FilterID    string                         `json:"filter_id"`
+	NextBatch   string                         `json:"next_batch"`
+	Rooms       map[id.RoomID]*mautrix.Room    `json:"rooms"`
+	Memberships map[id.RoomID]event.Membership `json:"memberships"`
 }
 
 //NewFileStore creates a new filestore
 func NewFileStore(path string) *FileStore {
-	return &FileStore{
+	store := FileStore{
 		path:  path,
-		Rooms: make(map[string]*mautrix.Room),
+		Rooms: make(map[id.RoomID]*mautrix.Room),
 	}
+	store.Load()
+	fmt.Println("File: ", store)
+	return &store
 }
 
 //Save saves the store
@@ -45,33 +52,34 @@ func (fs *FileStore) Load() error {
 }
 
 //SaveFilterID sets filterID and saves
-func (fs *FileStore) SaveFilterID(_, filterID string) {
+func (fs *FileStore) SaveFilterID(userID id.UserID, filterID string) {
 	fs.FilterID = filterID
 	fs.Save()
 }
 
 //LoadFilterID loadsFilterID
-func (fs *FileStore) LoadFilterID(_ string) string {
+func (fs *FileStore) LoadFilterID(userID id.UserID) string {
 	return fs.FilterID
 }
 
 //SaveNextBatch saves Next batch
-func (fs *FileStore) SaveNextBatch(_, nextBatchToken string) {
+func (fs *FileStore) SaveNextBatch(userID id.UserID, nextBatchToken string) {
 	fs.NextBatch = nextBatchToken
 	fs.Save()
 }
 
 //LoadNextBatch loads  next batch
-func (fs *FileStore) LoadNextBatch(_ string) string {
+func (fs *FileStore) LoadNextBatch(userID id.UserID) string {
 	return fs.NextBatch
 }
 
 //SaveRoom saves room
 func (fs *FileStore) SaveRoom(room *mautrix.Room) {
-	fs.Rooms[string(room.ID)] = room
+	fs.Rooms[room.ID] = room
+	fs.Save()
 }
 
 //LoadRoom loads room
-func (fs *FileStore) LoadRoom(roomID string) *mautrix.Room {
+func (fs *FileStore) LoadRoom(roomID id.RoomID) *mautrix.Room {
 	return fs.Rooms[roomID]
 }

--- a/main/FileStore.go
+++ b/main/FileStore.go
@@ -87,11 +87,12 @@ func (fs *FileStore) UpdateRoomState(roomID id.RoomID, evt *event.Event) {
 	room := fs.LoadRoom(roomID)
 	if room == nil {
 		room = mautrix.NewRoom(roomID)
-		fs.SaveRoom(room)
 	}
-	if room.State[event.StateMember][string(fs.userID)].Timestamp < evt.Timestamp {
+	event := room.State[event.StateMember][string(fs.userID)]
+	if event == nil || event.Timestamp < evt.Timestamp {
 		room.UpdateState(evt)
 	}
+	fs.SaveRoom(room)
 }
 
 func (fs *FileStore) GetMembershipState(roomID id.RoomID) (event.Membership, int64) {

--- a/main/Main.go
+++ b/main/Main.go
@@ -153,9 +153,10 @@ func startMatrixSync(client *mautrix.Client) {
 			// fmt.Println("Membership: ", evt.Content.AsMember().Membership)
 			// fmt.Println("Event type: ", evt.Type)
 			// fmt.Println("Source: ", source)
-			// fmt.Println(int(source))
-			// fmt.Println("Event: ", evt.Content.Parsed)
-			if source&mautrix.EventSourceInvite != 0 {
+			currentMembership := store.GetMembership(evt.RoomID, client.UserID)
+			// fmt.Println("Current Membership: ", currentMembership)
+			if source == mautrix.EventSourceInvite|mautrix.EventSourceState && currentMembership == event.MembershipInvite {
+				fmt.Println("Timestamp: ", time.UnixMilli(evt.Timestamp).Local())
 				fmt.Println("invited...")
 				host, err := getHostFromMatrixID(string(evt.Sender))
 				if err == -1 {
@@ -172,11 +173,8 @@ func startMatrixSync(client *mautrix.Client) {
 					WriteLog(critical, "")
 				}
 			}
-			if source&mautrix.EventSourceJoin != 0 {
-				fmt.Println("joined...")
-				// client.SendText(evt.RoomID, "Hey you have invited me to a new room. Enter !login to bridge this room to a Mail account")
-			}
-			if source&mautrix.EventSourceLeave != 0 {
+			if source == mautrix.EventSourceLeave|mautrix.EventSourceTimeline && currentMembership == event.MembershipLeave {
+				fmt.Println("Timestamp: ", time.UnixMilli(evt.Timestamp).Local())
 				fmt.Println("leaving...")
 				logOut(client, string(evt.RoomID), true)
 			}
@@ -188,15 +186,6 @@ func startMatrixSync(client *mautrix.Client) {
 		fmt.Println("Source: ", source)
 		fmt.Println(int(source))
 		fmt.Println("Sender: ", evt.Sender)
-		// fmt.Println(int(mautrix.EventSourceEphemeral))
-		// fmt.Println(int(mautrix.EventSourceLeave))
-		// fmt.Println(int(source & mautrix.EventSourceTimeline))
-		if evt.Sender == client.UserID {
-			return
-		}
-		// if evt.Sender != client.UserID && source&mautrix.EventSourceTimeline != 0 {
-		// 	return
-		// }
 		message := evt.Content.AsMessage().Body
 		roomID := evt.RoomID
 		fmt.Println("-------------")

--- a/main/Main.go
+++ b/main/Main.go
@@ -31,6 +31,7 @@ var db *sql.DB
 var matrixClient *mautrix.Client
 var tempDir = "temp/"
 var dirPrefix string
+var store *FileStore
 
 func initDB() error {
 	database, era := sql.Open("sqlite3", dirPrefix+"data.db")
@@ -91,7 +92,7 @@ func loginMatrix() {
 	if err != nil {
 		panic(err)
 	}
-	client.Store = NewFileStore(dirPrefix + "store.json")
+	client.Store = store
 	_, err = client.Login(&mautrix.ReqLogin{
 		Type:             "m.login.password",
 		Identifier:       mautrix.UserIdentifier{Type: mautrix.IdentifierTypeUser, User: viper.GetString("matrixuserid")},
@@ -912,6 +913,8 @@ func main() {
 	}
 
 	deleteAllWritingTemps()
+
+	store = NewFileStore(dirPrefix + "store.json")
 
 	loginMatrix()
 


### PR DESCRIPTION
## Problem
Same events are being consumed after the bot is removed and then added back into the room. This makes impossible to re-add the bot to the same room without first removing old messages.
### How to reproduce it
* Invite the bot to a room and configure it
* Run `!leave` command
* The bot is removed from the room
* Invite the bot again in the same room
#### What is expected to happen
* The bot joins and stays in the room
#### What actually happens
* The bot joins and then immediately leaves the room

## Cause
The bot reprocesses all events and as a result it executes `!leave` command again, even though it is an old one.
## Solution
Use the `FileStore` to persist the room state and make use of `membership state` and `timestamp` to ignore messages that were sent before the bot was invited into the room.
Additionally, avoid reprocessing same events between restarts by storing and using `nextBatchToken`