### PR TITLE
Fix charset handling, matrix login, channel panic and message formatting

### DIFF
--- a/main/MailHelper.go
+++ b/main/MailHelper.go
@@ -1,272 +1,295 @@
 package main
 
 import (
-	"crypto/tls"
-	"fmt"
-	"html"
-	"io"
-	"io/ioutil"
-	"log"
-	"maunium.net/go/mautrix/id"
-	"strings"
-	"time"
+        "crypto/tls"
+        "fmt"
+        "html"
+        "io"
+        "io/ioutil"
+        "log"
+        "maunium.net/go/mautrix/id"
+        "strings"
+        "time"
 
-	"github.com/emersion/go-imap"
-	"github.com/emersion/go-imap/client"
-	_ "github.com/emersion/go-message/charset"
-	"github.com/emersion/go-message/mail"
-	strip "github.com/grokify/html-strip-tags-go"
-	"maunium.net/go/mautrix"
+        "github.com/emersion/go-imap"
+        "github.com/emersion/go-imap/client"
+        "github.com/emersion/go-message/charset"
+        _ "github.com/emersion/go-message/charset"
+        "github.com/emersion/go-message/mail"
+        strip "github.com/grokify/html-strip-tags-go"
+        "golang.org/x/text/encoding"
+        "golang.org/x/text/encoding/charmap"
+        "maunium.net/go/mautrix"
 )
 
+func init() {
+        // Register additional charsets not handled by default
+        extraCharsets := map[string]encoding.Encoding{
+                "iso-8859-1":   charmap.ISO8859_1,
+                "iso-8859-2":   charmap.ISO8859_2,
+                "iso-8859-15":  charmap.ISO8859_15,
+                "windows-1250": charmap.Windows1250,
+                "windows-1251": charmap.Windows1251,
+                "windows-1252": charmap.Windows1252,
+        }
+        for name, enc := range extraCharsets {
+                encCopy := enc
+                charset.RegisterEncoding(name, encCopy)
+        }
+}
+
 func loginMail(host, username, password string, ignoreSSL bool) (*client.Client, error) {
-	ailClient, err := client.DialTLS(host, &tls.Config{InsecureSkipVerify: ignoreSSL})
+        ailClient, err := client.DialTLS(host, &tls.Config{InsecureSkipVerify: ignoreSSL})
 
-	if err != nil {
-		return nil, err
-	}
+        if err != nil {
+                return nil, err
+        }
 
-	if err := ailClient.Login(username, password); err != nil {
-		return nil, err
-	}
+        if err := ailClient.Login(username, password); err != nil {
+                return nil, err
+        }
 
-	return ailClient, nil
+        return ailClient, nil
 }
 
 func getMails(mClient *client.Client, mBox string, messages chan *imap.Message) (*imap.BodySectionName, int) {
-	mbox, err := mClient.Select(mBox, false)
-	if err != nil {
-		WriteLog(logError, "#12 couldnt get INBOX "+err.Error())
-		return nil, 0
-	}
+        mbox, err := mClient.Select(mBox, false)
+        if err != nil {
+                WriteLog(logError, "#12 couldnt get INBOX "+err.Error())
+                return nil, 0
+        }
 
-	if mbox == nil {
-		WriteLog(logError, "#23 getMails mbox is nli")
-		return nil, 0
-	}
+        if mbox == nil {
+                WriteLog(logError, "#23 getMails mbox is nli")
+                return nil, 0
+        }
 
-	if mbox.Messages == 0 {
-		WriteLog(logError, "#13 getMails no messages in inbox ")
-		return nil, 1
-	}
+        if mbox.Messages == 0 {
+                WriteLog(logError, "#13 getMails no messages in inbox ")
+                return nil, 1
+        }
 
-	seqSet := new(imap.SeqSet)
-	maxMessages := uint32(5)
-	if mbox.Messages < maxMessages {
-		maxMessages = mbox.Messages
-	}
-	for i := uint32(0); i < maxMessages; i++ {
-		seqSet.AddNum(mbox.Messages - i)
-	}
+        seqSet := new(imap.SeqSet)
+        maxMessages := uint32(5)
+        if mbox.Messages < maxMessages {
+                maxMessages = mbox.Messages
+        }
+        for i := uint32(0); i < maxMessages; i++ {
+                seqSet.AddNum(mbox.Messages - i)
+        }
 
-	section := &imap.BodySectionName{}
-	items := []imap.FetchItem{imap.FetchEnvelope, imap.FetchFlags, imap.FetchInternalDate, section.FetchItem()}
-	go func() {
-		if err := mClient.Fetch(seqSet, items, messages); err != nil {
-			WriteLog(critical, "#14 couldnt fetch messages: "+err.Error())
-		}
-	}()
-	return section, -1
+        section := &imap.BodySectionName{}
+        items := []imap.FetchItem{imap.FetchEnvelope, imap.FetchFlags, imap.FetchInternalDate, section.FetchItem()}
+        go func() {
+                if err := mClient.Fetch(seqSet, items, messages); err != nil {
+                        WriteLog(critical, "#14 couldnt fetch messages: "+err.Error())
+                }
+        }()
+        return section, -1
 }
 
 type email struct {
-	body, from, to, subject, attachment string
-	sendermails                         []string
-	date                                time.Time
-	htmlFormat                          bool
+        body, from, to, subject, attachment string
+        sendermails                         []string
+        date                                time.Time
+        htmlFormat                          bool
 }
 
 func getMailboxes(emailClient *client.Client) (string, error) {
-	// List mailboxes
-	mailboxes := make(chan *imap.MailboxInfo, 20)
-	done := make(chan error, 1)
-	go func() {
-		done <- emailClient.List("", "*", mailboxes)
-	}()
+        // List mailboxes
+        mailboxes := make(chan *imap.MailboxInfo, 20)
+        done := make(chan error, 1)
+        go func() {
+                done <- emailClient.List("", "*", mailboxes)
+        }()
 
-	mboxes := ""
-	for m := range mailboxes {
-		mboxes += "-> " + m.Name + "\r\n"
-	}
+        mboxes := ""
+        for m := range mailboxes {
+                mboxes += "-> " + m.Name + "\r\n"
+        }
 
-	if err := <-done; err != nil {
-		return "", err
-	}
-	return mboxes, nil
+        if err := <-done; err != nil {
+                return "", err
+        }
+        return mboxes, nil
 }
 
 func getMailContent(msg *imap.Message, section *imap.BodySectionName, roomID string) *email {
-	if msg == nil {
-		fmt.Println("msg is nil")
-		WriteLog(logError, "#15 getMailContent msg is nil")
-		return nil
-	}
+        if msg == nil {
+                fmt.Println("msg is nil")
+                WriteLog(logError, "#15 getMailContent msg is nil")
+                return nil
+        }
 
-	r := msg.GetBody(section)
-	if r == nil {
-		fmt.Println("reader is nli")
-		WriteLog(logError, "#16 getMailContent r (reader) is nil")
-		return nil
-	}
+        r := msg.GetBody(section)
+        if r == nil {
+                fmt.Println("reader is nli")
+                WriteLog(logError, "#16 getMailContent r (reader) is nil")
+                return nil
+        }
 
-	jmail := email{}
-	mr, err := mail.CreateReader(r)
-	if err != nil {
-		fmt.Println(err.Error())
-		WriteLog(logError, "#17 getMailContent create reader err: "+err.Error())
-		return nil
-	}
+        jmail := email{}
+        mr, err := mail.CreateReader(r)
+        if err != nil {
+                fmt.Println(err.Error())
+                WriteLog(logError, "#17 getMailContent create reader err: "+err.Error())
+                return nil
+        }
 
-	header := mr.Header
-	if date, err := header.Date(); err == nil {
-		log.Println("Date:", date)
-		jmail.date = date
-	}
-	if from, err := header.AddressList("From"); err == nil {
-		list := make([]string, len(from))
-		for i, sender := range from {
-			if len(sender.Name) > 0 {
-				list[i] = sender.Name + "<" + sender.Address + ">"
-			} else {
-				list[i] = sender.Address
-			}
-			jmail.sendermails = append(jmail.sendermails, sender.Address)
-		}
-		jmail.from = strings.Join(list, ",")
-	}
-	if to, err := header.AddressList("To"); err == nil {
-		list := make([]string, len(to))
-		for i, receiver := range to {
-			if len(receiver.Name) > 0 {
-				list[i] = receiver.Name + "<" + receiver.Address + ">"
-			} else {
-				list[i] = receiver.Address
-			}
-		}
-		jmail.to = strings.Join(list, ",")
-	}
-	if subject, err := header.Subject(); err == nil {
-		log.Println("Subject:", subject)
-		jmail.subject = subject
-	}
+        header := mr.Header
+        if date, err := header.Date(); err == nil {
+                log.Println("Date:", date)
+                jmail.date = date
+        }
+        if from, err := header.AddressList("From"); err == nil {
+                list := make([]string, len(from))
+                for i, sender := range from {
+                        if len(sender.Name) > 0 {
+                                list[i] = sender.Name + "<" + sender.Address + ">"
+                        } else {
+                                list[i] = sender.Address
+                        }
+                        jmail.sendermails = append(jmail.sendermails, sender.Address)
+                }
+                jmail.from = strings.Join(list, ",")
+        }
+        if to, err := header.AddressList("To"); err == nil {
+                list := make([]string, len(to))
+                for i, receiver := range to {
+                        if len(receiver.Name) > 0 {
+                                list[i] = receiver.Name + "<" + receiver.Address + ">"
+                        } else {
+                                list[i] = receiver.Address
+                        }
+                }
+                jmail.to = strings.Join(list, ",")
+        }
+        if subject, err := header.Subject(); err == nil {
+                log.Println("Subject:", subject)
+                jmail.subject = subject
+        }
 
-	htmlBody, plainBody := "", ""
-	_ = htmlBody
-	for {
-		p, err := mr.NextPart()
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			log.Println(err.Error())
-			WriteLog(critical, "#18 getMailContent nextPart err: "+err.Error())
-			break
-		}
+        htmlBody, plainBody := "", ""
+        _ = htmlBody
+        for {
+                p, err := mr.NextPart()
+                if err == io.EOF {
+                        break
+                } else if err != nil {
+                        log.Println("message:", err.Error())
+                        // Don't break on charset errors - skip part and continue
+                        if strings.Contains(err.Error(), "charset") || strings.Contains(err.Error(), "unhandled") {
+                                continue
+                        }
+                        WriteLog(critical, "#18 getMailContent nextPart err: "+err.Error())
+                        break
+                }
 
-		switch h := p.Header.(type) {
-		case *mail.InlineHeader:
-			b, _ := ioutil.ReadAll(p.Body)
-			bodycontent := string(b)
+                switch h := p.Header.(type) {
+                case *mail.InlineHeader:
+                        b, _ := ioutil.ReadAll(p.Body)
+                        bodycontent := string(b)
 
-			if strings.HasPrefix(p.Header.Get("Content-Type"), "text/html") {
-				htmlBody = bodycontent
-				continue
-			}
+                        if strings.HasPrefix(p.Header.Get("Content-Type"), "text/html") {
+                                htmlBody = bodycontent
+                                continue
+                        }
 
-			if strings.HasPrefix(p.Header.Get("Content-Type"), "text/plain") {
-				plainBody = bodycontent
-				continue
-			}
+                        if strings.HasPrefix(p.Header.Get("Content-Type"), "text/plain") {
+                                plainBody = bodycontent
+                                continue
+                        }
 
-			plainBody = bodycontent
-		case *mail.AttachmentHeader:
-			filename, _ := h.Filename()
-			jmail.attachment += string(filename) + "\r\n"
-		}
-	}
-	isEnabled, eror := isHTMLenabled(roomID)
-	if eror != nil {
-		WriteLog(critical, "#55 isHTMLenabled: "+eror.Error())
-	}
-	if len(htmlBody) > 0 && isEnabled {
-		jmail.body = html.UnescapeString(htmlBody)
-		jmail.htmlFormat = true
-	} else {
-		if len(strings.Trim(plainBody, " ")) == 0 {
-			plainBody = htmlBody
-		}
-		parseMailBody(&plainBody)
-		jmail.body = plainBody
-		jmail.htmlFormat = false
-	}
+                        plainBody = bodycontent
+                case *mail.AttachmentHeader:
+                        filename, _ := h.Filename()
+                        jmail.attachment += string(filename) + "\r\n"
+                }
+        }
+        isEnabled, eror := isHTMLenabled(roomID)
+        if eror != nil {
+                WriteLog(critical, "#55 isHTMLenabled: "+eror.Error())
+        }
+        if len(htmlBody) > 0 && isEnabled {
+                jmail.body = html.UnescapeString(htmlBody)
+                jmail.htmlFormat = true
+        } else {
+                if len(strings.Trim(plainBody, " ")) == 0 {
+                        plainBody = htmlBody
+                }
+                parseMailBody(&plainBody)
+                jmail.body = plainBody
+                jmail.htmlFormat = false
+        }
 
-	return &jmail
+        return &jmail
 }
 
 func parseMailBody(body *string) {
-	*body = strings.ReplaceAll(*body, "<br>", "\r\n")
-	*body = strip.StripTags(html.UnescapeString(*body))
+        *body = strings.ReplaceAll(*body, "<br>", "\r\n")
+        *body = strip.StripTags(html.UnescapeString(*body))
 }
 
 func viewMailbox(roomID string, client *mautrix.Client) {
-	imapAccID, _, erro := getRoomAccounts(roomID)
-	if erro != nil {
-		WriteLog(critical, "#50 getRoomAccounts: "+erro.Error())
-		client.SendText(id.RoomID(roomID), "An server-error occured Errorcode: #50")
-		return
-	}
-	if imapAccID != -1 {
-		mailbox, err := getMailbox(roomID)
-		if err != nil {
-			WriteLog(critical, "#51 getMailbox: "+err.Error())
-			client.SendText(id.RoomID(roomID), "An server-error occured Errorcode: #51")
-			return
-		}
-		client.SendText(id.RoomID(roomID), "The current mailbox for this room is: "+mailbox)
-	} else {
-		client.SendText(id.RoomID(roomID), "You have to setup an IMAP account to use this command. Use !setup or !login for more informations")
-	}
+        imapAccID, _, erro := getRoomAccounts(roomID)
+        if erro != nil {
+                WriteLog(critical, "#50 getRoomAccounts: "+erro.Error())
+                client.SendText(id.RoomID(roomID), "An server-error occured Errorcode: #50")
+                return
+        }
+        if imapAccID != -1 {
+                mailbox, err := getMailbox(roomID)
+                if err != nil {
+                        WriteLog(critical, "#51 getMailbox: "+err.Error())
+                        client.SendText(id.RoomID(roomID), "An server-error occured Errorcode: #51")
+                        return
+                }
+                client.SendText(id.RoomID(roomID), "The current mailbox for this room is: "+mailbox)
+        } else {
+                client.SendText(id.RoomID(roomID), "You have to setup an IMAP account to use this command. Use !setup or !login for more informations")
+        }
 }
 
 func viewMailboxes(roomID string, client *mautrix.Client) {
-	imapAccID, _, erro := getRoomAccounts(roomID)
-	if erro != nil {
-		WriteLog(critical, "#48 getRoomAccounts: "+erro.Error())
-		client.SendText(id.RoomID(roomID), "An server-error occured Errorcode: #48")
-		return
-	}
-	if imapAccID != -1 {
-		mailboxes, err := getMailboxes(clients[roomID])
-		if err != nil {
-			WriteLog(critical, "#47 getMailboxes: "+err.Error())
-			client.SendText(id.RoomID(roomID), "An server-error occured Errorcode: #47")
-			return
-		}
-		client.SendText(id.RoomID(roomID), "Your mailboxes:\r\n"+mailboxes+"\r\nUse !setmailbox <mailbox> to change your mailbox")
-	} else {
-		client.SendText(id.RoomID(roomID), "You have to setup an IMAP account to use this command. Use !setup or !login for more informations")
-	}
+        imapAccID, _, erro := getRoomAccounts(roomID)
+        if erro != nil {
+                WriteLog(critical, "#48 getRoomAccounts: "+erro.Error())
+                client.SendText(id.RoomID(roomID), "An server-error occured Errorcode: #48")
+                return
+        }
+        if imapAccID != -1 {
+                mailboxes, err := getMailboxes(clients[roomID])
+                if err != nil {
+                        WriteLog(critical, "#47 getMailboxes: "+err.Error())
+                        client.SendText(id.RoomID(roomID), "An server-error occured Errorcode: #47")
+                        return
+                }
+                client.SendText(id.RoomID(roomID), "Your mailboxes:\r\n"+mailboxes+"\r\nUse !setmailbox <mailbox> to change your mailbox")
+        } else {
+                client.SendText(id.RoomID(roomID), "You have to setup an IMAP account to use this command. Use !setup or !login for more informations")
+        }
 }
 
 func viewBlocklist(roomID string, client *mautrix.Client) {
-	imapAccID, _, erro := getRoomAccounts(roomID)
-	if erro != nil {
-		WriteLog(critical, "#48 getRoomAccounts: "+erro.Error())
-		client.SendText(id.RoomID(roomID), "An server-error occured Errorcode: #48")
-		return
-	}
-	if imapAccID != -1 {
-		blocklist := getBlocklist(imapAccID)
-		var msg string
-		if len(blocklist) > 0 {
-			msg = "Blocked addresses:\n"
-			for _, blo := range blocklist {
-				msg += "> " + blo + "\n"
-			}
-		} else {
-			msg = "No addresses blocked!"
-		}
-		client.SendText(id.RoomID(roomID), msg)
-	} else {
-		client.SendText(id.RoomID(roomID), "You have to setup an IMAP account to use this command. Use !setup or !login for more informations")
-	}
+        imapAccID, _, erro := getRoomAccounts(roomID)
+        if erro != nil {
+                WriteLog(critical, "#48 getRoomAccounts: "+erro.Error())
+                client.SendText(id.RoomID(roomID), "An server-error occured Errorcode: #48")
+                return
+        }
+        if imapAccID != -1 {
+                blocklist := getBlocklist(imapAccID)
+                var msg string
+                if len(blocklist) > 0 {
+                        msg = "Blocked addresses:\n"
+                        for _, blo := range blocklist {
+                                msg += "> " + blo + "\n"
+                        }
+                } else {
+                        msg = "No addresses blocked!"
+                }
+                client.SendText(id.RoomID(roomID), msg)
+        } else {
+                client.SendText(id.RoomID(roomID), "You have to setup an IMAP account to use this command. Use !setup or !login for more informations")
+        }
 }

--- a/main/Main.go
+++ b/main/Main.go
@@ -86,6 +86,24 @@ func initCfg() bool {
 
 func loginMatrix() {
 	fmt.Println("Logging into", viper.GetString("matrixserver"), "as", viper.GetString("matrixuserid"))
+
+	// If an access token is already stored, use it directly without password login
+	existingToken := viper.GetString("matrixaccesstoken")
+	if existingToken != "" {
+		fmt.Println("Found existing access token, skipping password login")
+		client, err := mautrix.NewClient(viper.GetString("matrixserver"), id.UserID(viper.GetString("matrixuserid")), existingToken)
+		if err == nil {
+			_, err = client.Whoami()
+			if err == nil {
+				fmt.Println("Access token valid, login successful")
+				matrixClient = client
+				go startMatrixSync(client)
+				return
+			}
+			fmt.Println("Access token invalid or expired, falling back to password login:", err.Error())
+		}
+	}
+
 	client, err := mautrix.NewClient(viper.GetString("matrixserver"), "", "")
 	if err != nil {
 		panic(err)
@@ -159,8 +177,15 @@ func startMatrixSync(client *mautrix.Client) {
 	})
 
 	syncer.OnEventType(event.StateMember, func(source mautrix.EventSource, evt *event.Event) {
-		if evt.Sender != client.UserID && evt.Content.AsMember().Membership == "leave" {
-			logOut(client, string(evt.RoomID), true)
+		// Ignore historical events (older than 30 seconds)
+		if evt.Unsigned.Age > 30000 {
+			return
+		}
+		// Only react if the bot itself was kicked/banned
+		if evt.StateKey != nil && id.UserID(*evt.StateKey) == client.UserID {
+			if evt.Content.AsMember().Membership == "leave" || evt.Content.AsMember().Membership == "ban" {
+				logOut(client, string(evt.RoomID), true)
+			}
 		}
 	})
 
@@ -892,10 +917,10 @@ func main() {
 }
 
 func stopMailChecker(roomID string) {
-	_, ok := listenerMap[roomID]
+	ch, ok := listenerMap[roomID]
 	if ok {
-		close(listenerMap[roomID])
-		//delete(listenerMap, evt.RoomID)
+		delete(listenerMap, roomID)
+		close(ch)
 	}
 }
 
@@ -1047,25 +1072,25 @@ func handleMail(mail *imap.Message, section *imap.BodySectionName, account imapA
 		}
 	}
 	from := html.EscapeString(content.from)
-	fmt.Println("attachments: " + content.attachment)
-	headerContent := &event.MessageEventContent{
+	// Combine header and body into a single message
+	separator := "\r\n────────────────────────────────────\r\n"
+	separatorHTML := "<br>────────────────────────────────────<br>"
+
+	plainHeader := separator + "You've got a new Email from " + from + "\r\nSubject: " + content.subject + separator
+	htmlHeader := separatorHTML + "<b>You've got a new Email</b> from <b>" + from + "</b><br>Subject: " + content.subject + separatorHTML
+
+	var combinedHTMLBody string
+	if content.htmlFormat {
+		combinedHTMLBody = htmlHeader + string(markdown.ToHTML([]byte(content.body), nil, nil))
+	} else {
+		combinedHTMLBody = htmlHeader + content.body
+	}
+
+	combinedContent := &event.MessageEventContent{
 		Format:        event.FormatHTML,
-		Body:          "\r\n────────────────────────────────────\r\n## You've got a new Email from " + from + "\r\n" + "Subject: " + content.subject + "\r\n" + "────────────────────────────────────",
-		FormattedBody: "<br>────────────────────────────────────<br><b> You've got a new Email</b> from <b>" + from + "</b><br>" + "Subject: " + content.subject + "<br>" + "────────────────────────────────────",
+		Body:          plainHeader + content.body,
+		FormattedBody: combinedHTMLBody,
 		MsgType:       event.MsgText,
 	}
-
-	matrixClient.SendMessageEvent(id.RoomID(account.roomID), event.EventMessage, &headerContent)
-
-	if content.htmlFormat {
-		bodyContent := &event.MessageEventContent{
-			Format:        event.FormatHTML,
-			Body:          content.body,
-			FormattedBody: string(markdown.ToHTML([]byte(content.body), nil, nil)),
-			MsgType:       event.MsgText,
-		}
-		matrixClient.SendMessageEvent(id.RoomID(account.roomID), event.EventMessage, &bodyContent)
-	} else {
-		matrixClient.SendText(id.RoomID(account.roomID), content.body)
-	}
+	matrixClient.SendMessageEvent(id.RoomID(account.roomID), event.EventMessage, &combinedContent)
 }


### PR DESCRIPTION
- Register additional charsets (ISO-8859-1, Windows-125x) to prevent
  silent mail content loss for non-UTF-8 encoded messages
- Skip mail parts with unhandled charsets instead of aborting the
  entire mail parsing loop
- Use existing access token from config for matrix login instead of
  always requiring password login
- Fix "close of closed channel" panic in stopMailChecker by deleting
  the channel from the map before closing it
- Fix bot leaving rooms on startup by ignoring historical StateMember
  leave events (age > 30s) and only reacting when the bot itself is
  affected
- Combine mail header and body into a single matrix message to prevent
  interleaving when multiple mails arrive simultaneously